### PR TITLE
add station location modal

### DIFF
--- a/src/app/toolbox/components/display/geometry-map-viewer/geometry-map-viewer.component.ts
+++ b/src/app/toolbox/components/display/geometry-map-viewer/geometry-map-viewer.component.ts
@@ -48,6 +48,8 @@ export class GeometryMapViewerComponent implements AfterViewInit, OnChanges {
         }).addTo(this.map);
 
         this.drawGeometry();
+
+        window.setTimeout(()=>this.map.invalidateSize(), 1000)
     }
 
     public ngOnChanges(changes: SimpleChanges) {

--- a/src/app/toolbox/components/display/legend-entry/legend-entry.component.html
+++ b/src/app/toolbox/components/display/legend-entry/legend-entry.component.html
@@ -14,6 +14,21 @@
     </div>
 </ng-template>
 
+<ng-template #modalGeometryViewer let-c="close" let-d="dismiss">
+    <div class="modal-header">
+        <h4 class="modal-title">Station location</h4>
+        <button type="button" class="close" aria-label="Close" (click)="d()">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    <div class="modal-body">
+        <n52-geometry-map-viewer [mapId]="'mapGeometryViewerModal'" [geometry]="dataset.station.geometry" [maxMapZoom]="15"></n52-geometry-map-viewer>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-light" (click)="c();">Close</button>
+    </div>
+</ng-template>
+
 <div class="legendItem" style="position: relative;" [ngStyle]="{'border-color': dataset.styles.color}" [ngClass]="{'selected': dataset.styles.selected}" (click)="toggleSelection()">
     <div class="loading-overlay" *ngIf="dataset.styles.loading" [ngStyle]="{'background-color': dataset.styles.color}">
         <div class="fa fa-refresh fa-spin fa-3x fa-fw"></div>
@@ -56,7 +71,7 @@
         </div>
         <div class="legendicons">
             <span class="fa" [ngClass]="{'fa-eye-slash': dataset.styles.visible, 'fa-eye': !dataset.styles.visible}" (click)="toggleVisibility(); $event.stopPropagation();"></span>
-            <!-- <swc-timeseries-geometry-view-button series="timeseries"></swc-timeseries-geometry-view-button> -->
+            <span class="fa fa-map-marker" (click)="open(modalGeometryViewer, 'geometryViewerModal'); $event.stopPropagation();"></span>
             <span class="fa fa-pencil" (click)="open(modalTimeseriesStyleSelector); $event.stopPropagation();" [ngStyle]="{color: dataset.styles.color}"></span>
             <span class="fa fa-info" (click)="toggleInformation(); $event.stopPropagation();"></span>
             <span class="fa fa-times" (click)="removeDataset(); $event.stopPropagation();"></span>

--- a/src/app/toolbox/components/display/legend-entry/legend-entry.component.scss
+++ b/src/app/toolbox/components/display/legend-entry/legend-entry.component.scss
@@ -1,6 +1,13 @@
 @import '../../../../../variables';
 
-:host {
+
+.geometryViewerModal {
+    .modal-body {
+        height: 50vh;
+    }
+}
+
+n52-legend-entry {
     .legendItem {
         background-color: white;
         padding: 5px;

--- a/src/app/toolbox/components/display/legend-entry/legend-entry.component.ts
+++ b/src/app/toolbox/components/display/legend-entry/legend-entry.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { Dataset } from './../../../model/api/dataset/dataset';
 import { FirstLastValue } from './../../../model/api/dataset/firstLastValue';
@@ -10,7 +10,8 @@ import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 @Component({
     selector: 'n52-legend-entry',
     templateUrl: './legend-entry.component.html',
-    styleUrls: ['./legend-entry.component.scss']
+    styleUrls: ['./legend-entry.component.scss'],
+    encapsulation: ViewEncapsulation.None
 })
 export class LegendEntryComponent implements OnInit {
 
@@ -82,7 +83,7 @@ export class LegendEntryComponent implements OnInit {
         return !this.dataset.styles.loading && !this.dataset.hasData;
     }
 
-    public open(content: TemplateRef<any>) {
-        this.modalService.open(content, {size: 'lg'});
+    public open(content: TemplateRef<any>, className: string = '') {
+        this.modalService.open(content, {size: 'lg', windowClass: className});
     }
 }


### PR DESCRIPTION
Introduces a tweak to geometry-map-viewer: map.invalidateSize() is called after 1 second to refresh Leaflet's idea of the dimensions of the map. This is necessary because when the viewer is opened in a modal window, Leaflet initially thinks the map has a height 0, causing tiles not to load properly.